### PR TITLE
Add wheels index page

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -1,0 +1,36 @@
+---
+name: Generate Index
+
+"on":
+  push:
+    branches:
+      - main
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate index.html
+        run: |
+          mkdir output
+          python generate_index.py > output/index.html
+          cp *.whl output
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: output
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Pyodide Test Wheels
+
+This repository hosts WebAssembly (WASM) wheels for the [ifcopenshell](https://github.com/IfcOpenShell/IfcOpenShell) library, optimized for use with [Pyodide](https://pyodide.org/).
+
+## Purpose
+
+The purpose of this repository is to provide a centralized, publicly accessible source for ifcopenshell wheels, allowing users to install them via URL without needing to host the files themselves.
+After [PEP783](https://peps.python.org/pep-0783/) will be accepted, we'll be able to move those wheels to PyPI.
+
+## Available Wheels
+
+The repository contains several versions of ifcopenshell wheels compiled for Pyodide/WASM. An auto-generated index of available wheels is available at: [https://ifcopenshell.github.io/wasm-wheels/](https://ifcopenshell.github.io/wasm-wheels/)
+
+## Installation in Pyodide
+
+To install a wheel in Pyodide:
+
+```python
+import micropip
+await micropip.install("https://ifcopenshell.github.io/wasm-wheels/ifcopenshell-0.8.3+34a1bc6-cp313-cp313-emscripten_4_0_9_wasm32.whl")
+```
+
+Replace the URL with the desired wheel filename from the index.
+
+## Alternatives Considered
+
+Other hosting options were considered:
+- Raw files from GitHub repository commits: Do not serve proper CORS headers.
+- Files in GitHub Releases: Do not serve proper CORS headers.
+
+GitHub Pages was chosen as it automatically includes Access-Control-Allow-Origin: * headers, enabling cross-origin requests required for Pyodide installations.

--- a/generate_index.py
+++ b/generate_index.py
@@ -1,0 +1,32 @@
+import glob
+import os
+
+# Generate index.html in root listing all .whl files
+
+html_content = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IfcOpenShell Pyodide Wheels</title>
+</head>
+<body>
+    <h1>Available IfcOpenShell Pyodide Wheels</h1>
+    <p><a href="https://github.com/IfcOpenShell/wasm-wheels#pyodide-test-wheels">See README for details</a></p>
+    <ul>
+"""
+
+# Find all .whl files in the repo, sorted descending
+whl_files = sorted(glob.glob("**/*.whl", recursive=True), reverse=True)
+
+for whl_file in whl_files:
+    filename = os.path.basename(whl_file)
+    # Since index.html is in root, link to filename
+    html_content += f'        <li><a href="{filename}">{filename}</a></li>\n'
+
+html_content += """    </ul>
+</body>
+</html>
+"""
+
+print(html_content)


### PR DESCRIPTION
Hi! Wanted to add index page (see https://andrej730.github.io/pyodide-test/ as an example)

So users could use those urls directly in pyodide code to install build they need:
```python
import micropip
await micropip.install("https://andrej730.github.io/pyodide-test/ifcopenshell-0.8.3+34a1bc6-cp313-cp313-emscripten_4_0_9_wasm32.whl")
```

Will also add a note about this to https://docs.ifcopenshell.org/ifcopenshell-python/installation.html#web-assembly to make it discoverable.

Though we'll need to enable pages for this repo.